### PR TITLE
Add perturbation branching and tests

### DIFF
--- a/neuro_lattice/perturbations.py
+++ b/neuro_lattice/perturbations.py
@@ -1,13 +1,40 @@
+import random
 import networkx as nx
 
 class PerturbationInjector:
     """Minimal perturbation helper for tests."""
 
     def inject_perturbation(self, lattice: nx.Graph, perturbation_type: str = "adversarial"):
-        """Apply a simple weight perturbation to an edge in the lattice."""
+        """Apply different perturbations to the first edge of the lattice.
+
+        Parameters
+        ----------
+        lattice:
+            Graph whose first edge will be perturbed. If the graph has no
+            edges, it is returned unchanged.
+        perturbation_type:
+            The type of perturbation to apply. Supported values are
+            "adversarial" and "random-noise".
+        """
         if lattice.number_of_edges() == 0:
             return lattice
+
+        # Grab the first edge and its data dictionary. This keeps the helper
+        # deterministic and easy to reason about for tests.
         edge = next(iter(lattice.edges(data=True)))
         data = edge[2]
-        data["weight"] = data.get("weight", 1.0) * 5
+        weight = data.get("weight", 1.0)
+
+        if perturbation_type == "adversarial":
+            # Dramatically increase the weight to simulate an adversarial
+            # manipulation of the edge cost.
+            data["weight"] = weight * 5
+        elif perturbation_type == "random-noise":
+            # Inject bounded random noise into the weight. The magnitude is
+            # intentionally small so tests can seed the RNG and assert exact
+            # values.
+            data["weight"] = weight + random.uniform(-0.5, 0.5)
+        else:
+            raise ValueError(f"Unsupported perturbation_type: {perturbation_type}")
+
         return lattice

--- a/tests/test_perturbations.py
+++ b/tests/test_perturbations.py
@@ -1,0 +1,18 @@
+import random
+import networkx as nx
+import pytest
+
+from neuro_lattice.perturbations import PerturbationInjector
+
+def test_adversarial_perturbation():
+    G = nx.Graph()
+    G.add_edge(1, 2, weight=1.0)
+    PerturbationInjector().inject_perturbation(G, perturbation_type="adversarial")
+    assert G[1][2]["weight"] == 5.0
+
+def test_random_noise_perturbation():
+    random.seed(0)
+    G = nx.Graph()
+    G.add_edge(1, 2, weight=1.0)
+    PerturbationInjector().inject_perturbation(G, perturbation_type="random-noise")
+    assert G[1][2]["weight"] == pytest.approx(1.3444218515250481)


### PR DESCRIPTION
## Summary
- support adversarial and random-noise modes in `PerturbationInjector`
- test perturbation modes with deterministic noise

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f4c912da4832da7f2e5fc33a58559