### PR TITLE
Expose CognitiveNetwork and bump version to 0.1.1

### DIFF
--- a/neuro_lattice/__init__.py
+++ b/neuro_lattice/__init__.py
@@ -1,3 +1,9 @@
-from .lattice_builder import LatticeBuilder
 from .cognitive_network import CognitiveNetwork
+from .lattice_builder import LatticeBuilder
 from .perturbation import PerturbationEngine
+
+__all__ = [
+    "CognitiveNetwork",
+    "LatticeBuilder",
+    "PerturbationEngine",
+]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="neuro_lattice",
-    version="0.1.0",
+    version="0.1.1",
     description="Symmetry-driven coherence framework for next-gen intelligence",
     author="David Berigny",
     packages=find_packages(include=["neuro_lattice", "neuro_lattice.*"]),


### PR DESCRIPTION
## Summary
- Expose CognitiveNetwork via package initializer and define `__all__`
- Bump package version to 0.1.1

## Testing
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=42)*
- `python - <<'PY'
from neuro_lattice.cognitive_network import CognitiveNetwork
print(CognitiveNetwork)
PY`
- `pytest` *(fails: AttributeError: 'CognitiveNetwork' object has no attribute 'add_concept')*

------
https://chatgpt.com/codex/tasks/task_e_688f61b58704832d8edf0090b2be38b7