### PR TITLE
Remove SciPy as a direct dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ networkx>=3.2.1
 numpy>=1.23
 matplotlib>=3.7
 pandas>=1.5
-scipy>=1.11

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ setup(
         "opencv-python",
         "numpy",
         "scikit-image",
-        "scikit-learn",
-        "scipy"
+        "scikit-learn"
     ],
 )


### PR DESCRIPTION
## Summary
- drop SciPy from direct dependencies in requirements and setup

## Testing
- `pytest` *(fails: AttributeError: 'CognitiveNetwork' object has no attribute 'add_concept')*

------
https://chatgpt.com/codex/tasks/task_e_688f61bd3620832db7870bcdb2e9debb