### PR TITLE
Handle empty visit counts in metrics

### DIFF
--- a/neuro_lattice/metrics.py
+++ b/neuro_lattice/metrics.py
@@ -49,6 +49,8 @@ def node_visit_imbalance(visit_counts):
     """
     Imbalance = max node visits / mean visits.
     """
+    if not visit_counts:
+        return 0.0
     visits = np.array(list(visit_counts.values()))
     return visits.max() / (visits.mean() + 1e-8)
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,6 +1,6 @@
 import math
 import networkx as nx
-from neuro_lattice.metrics import calculate_strain, calculate_coherence
+from neuro_lattice.metrics import calculate_strain, calculate_coherence, node_visit_imbalance
 
 
 def build_lattice():
@@ -29,3 +29,7 @@ def test_strain_threshold():
 def test_coherence_threshold():
     g = build_lattice()
     assert calculate_coherence(g) > 0.5
+
+
+def test_node_visit_imbalance_empty():
+    assert node_visit_imbalance({}) == 0.0


### PR DESCRIPTION
## Summary
- Guard against empty visit data in `node_visit_imbalance` and return 0.0 when no visits exist
- Add unit test verifying `node_visit_imbalance` handles empty input

## Testing
- `pytest tests/test_metrics.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f61bb0ec8832da6fc46ef811a9125