### PR TITLE
Implement lattice scaling and update tests

### DIFF
--- a/neuro_lattice/cognitive_network.py
+++ b/neuro_lattice/cognitive_network.py
@@ -14,7 +14,7 @@ class CognitiveNetwork:
     lattice_type:
         Shape of lattice to build. Currently ``'tetrahedral'`` or ``'cubic'``.
     size:
-        Scaling factor passed to :class:`~neuro_lattice.lattice_builder.LatticeBuilder`.
+        Scaling factor for node positions and edge weights in the lattice.
     """
 
     def __init__(self, lattice_type: str = "tetrahedral", size: float = 1.0) -> None:

--- a/neuro_lattice/lattice_builder.py
+++ b/neuro_lattice/lattice_builder.py
@@ -1,3 +1,4 @@
+import math
 import networkx as nx
 
 class LatticeBuilder:
@@ -17,31 +18,70 @@ class LatticeBuilder:
 
     def _build_tetrahedral_lattice(self):
         G = nx.DiGraph()
-        nodes = list(range(8)) + ['IC', 'EC']  # 8 lattice nodes + internal/external centroids
+        nodes = list(range(8)) + ["IC", "EC"]
         G.add_nodes_from(nodes)
 
-        # Tetrahedron 1 (0-3)
-        tetra1 = [(0,1),(0,2),(0,3),(1,2),(1,3),(2,3)]
-        # Tetrahedron 2 (4-7)
-        tetra2 = [(4,5),(4,6),(4,7),(5,6),(5,7),(6,7)]
+        # Base coordinates for two tetrahedra and centroids
+        base_pos = {
+            0: (0.0, 0.0, 0.0),
+            1: (1.0, 0.0, 0.0),
+            2: (0.0, 1.0, 0.0),
+            3: (0.0, 0.0, 1.0),
+            4: (1.0, 1.0, 1.0),
+            5: (2.0, 1.0, 1.0),
+            6: (1.0, 2.0, 1.0),
+            7: (1.0, 1.0, 2.0),
+            "IC": (0.5, 0.5, 0.5),
+            "EC": (1.5, 1.5, 1.5),
+        }
+
+        # Scale coordinates by lattice size
+        pos = {n: (x * self.size, y * self.size, z * self.size) for n, (x, y, z) in base_pos.items()}
+        nx.set_node_attributes(G, pos, "pos")
+
+        # Tetrahedron 1 (0-3) and Tetrahedron 2 (4-7)
+        tetra1 = [(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)]
+        tetra2 = [(4, 5), (4, 6), (4, 7), (5, 6), (5, 7), (6, 7)]
         G.add_edges_from(tetra1 + tetra2)
 
         # Cross edges (connect tetrahedra)
-        cross_edges = [(0,4),(1,5),(2,6),(3,7)]
+        cross_edges = [(0, 4), (1, 5), (2, 6), (3, 7)]
         G.add_edges_from(cross_edges)
 
         # Centroid connections
         centroid_edges = [
-            ('EC','IC'), ('EC',0), ('EC',4),
-            (0,'EC'), (4,'EC'), (6,'EC'), (7,'EC')
+            ("EC", "IC"), ("EC", 0), ("EC", 4),
+            (0, "EC"), (4, "EC"), (6, "EC"), (7, "EC"),
         ]
         G.add_edges_from(centroid_edges)
+
+        # Assign edge weights based on Euclidean distance
+        for u, v in G.edges():
+            p1, p2 = pos[u], pos[v]
+            G.edges[u, v]["weight"] = math.dist(p1, p2)
 
         return G
 
     def _build_cubic_lattice(self):
-        G = nx.grid_3d_graph(2, 2, 2)  # basic 2x2x2 cube lattice
-        return nx.convert_node_labels_to_integers(G)
+        # Nodes in grid_3d_graph are coordinates (x, y, z)
+        base = nx.grid_3d_graph(2, 2, 2)
+
+        # Convert to directed graph with bidirectional edges
+        base = base.to_directed()
+
+        # Map coordinate nodes to integer labels while storing positions
+        mapping = {node: i for i, node in enumerate(base.nodes())}
+        pos = {mapping[node]: (node[0] * self.size, node[1] * self.size, node[2] * self.size) for node in base.nodes()}
+
+        G = nx.relabel_nodes(base, mapping, copy=True)
+        nx.set_node_attributes(G, pos, "pos")
+
+        # Assign edge weights
+        for u, v in G.edges():
+            p1, p2 = pos[u], pos[v]
+            G.edges[u, v]["weight"] = math.dist(p1, p2)
+
+        return G
 
     def set_lattice_parameters(self, lattice_type, size):
         self.lattice_type = lattice_type

--- a/tests/test_cognitive_network.py
+++ b/tests/test_cognitive_network.py
@@ -1,13 +1,14 @@
+import networkx as nx
 from neuro_lattice import CognitiveNetwork
 
 
 def test_cognitive_network_basic():
-    network = CognitiveNetwork()
-    network.add_concept("A")
-    network.add_concept("B")
-    network.add_relation("A", "B", weight=0.5)
+    cn = CognitiveNetwork(lattice_type="tetrahedral", size=1.0)
+    graph = cn.get_network()
 
-    adj = network.adjacency_matrix()
+    # Graph should be a directed graph with the expected number of nodes
+    assert isinstance(graph, nx.DiGraph)
+    assert len(graph) == 10
 
-    assert adj.shape == (2, 2)
-    assert adj[0, 1] == 0.5
+    # Node positions should be available from the builder
+    assert graph.nodes[1]["pos"] == (1.0, 0.0, 0.0)

--- a/tests/test_lattice.py
+++ b/tests/test_lattice.py
@@ -1,7 +1,19 @@
 import pytest
 from neuro_lattice.lattice_builder import LatticeBuilder
 
-def test_lattice_build():
-    lb = LatticeBuilder(lattice_type='tetrahedral')
-    lattice = lb.build_lattice()
-    assert lattice is not None
+
+def test_lattice_build_and_scaling():
+    lb = LatticeBuilder(lattice_type="tetrahedral", size=1.0)
+    lattice1 = lb.build_lattice()
+
+    # Positions should be stored and scale with the size parameter
+    assert lattice1.nodes[1]["pos"] == (1.0, 0.0, 0.0)
+
+    lb_scaled = LatticeBuilder(lattice_type="tetrahedral", size=2.0)
+    lattice2 = lb_scaled.build_lattice()
+    assert lattice2.nodes[1]["pos"] == (2.0, 0.0, 0.0)
+
+    # Edge weights also scale linearly
+    w1 = lattice1.edges[(0, 1)]["weight"]
+    w2 = lattice2.edges[(0, 1)]["weight"]
+    assert pytest.approx(w2) == w1 * 2


### PR DESCRIPTION
## Summary
- add coordinate scaling and edge weights to lattices via `size`
- clarify `CognitiveNetwork` size parameter
- expand tests to cover lattice scaling and align cognitive network tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f61b77bcc832db12d61bf6a65f47b